### PR TITLE
Fix most of the broken tests

### DIFF
--- a/core/src/main/java/org/elasticsearch/index/mapper/core/StringFieldMapper.java
+++ b/core/src/main/java/org/elasticsearch/index/mapper/core/StringFieldMapper.java
@@ -70,7 +70,12 @@ public class StringFieldMapper extends FieldMapper implements AllFieldMapper.Inc
 
         protected String nullValue = Defaults.NULL_VALUE;
 
-        protected int positionOffsetGap = Defaults.POSITION_OFFSET_GAP;
+        /**
+         * The offset gap between different values of the same field. -1 means
+         * use the default from the analyzer which in turn defaults to
+         * StringFieldMapp.Defaults.POSITION_OFFSET_GAP.
+         */
+        protected int positionOffsetGap = -1;
 
         protected int ignoreAbove = Defaults.IGNORE_ABOVE;
 
@@ -102,10 +107,20 @@ public class StringFieldMapper extends FieldMapper implements AllFieldMapper.Inc
 
         @Override
         public StringFieldMapper build(BuilderContext context) {
-            if (positionOffsetGap > 0) {
-                fieldType.setIndexAnalyzer(new NamedAnalyzer(fieldType.indexAnalyzer(), positionOffsetGap));
-                fieldType.setSearchAnalyzer(new NamedAnalyzer(fieldType.searchAnalyzer(), positionOffsetGap));
-                fieldType.setSearchQuoteAnalyzer(new NamedAnalyzer(fieldType.searchQuoteAnalyzer(), positionOffsetGap));
+            // Let the mapping override the position_offset_gap in the analyzer if it is different.
+            if (positionOffsetGap != -1) {
+                if (fieldType.indexAnalyzer() != null &&
+                        positionOffsetGap != fieldType.indexAnalyzer().getOffsetGap(fieldType.indexAnalyzer().name())) {
+                    fieldType.setIndexAnalyzer(new NamedAnalyzer(fieldType.indexAnalyzer(), positionOffsetGap));                
+                }
+                if (fieldType.searchAnalyzer() != null &&
+                        positionOffsetGap != fieldType.searchAnalyzer().getOffsetGap(fieldType.searchAnalyzer().name())) {
+                    fieldType.setSearchAnalyzer(new NamedAnalyzer(fieldType.searchAnalyzer(), positionOffsetGap));                
+                }
+                if (fieldType.searchQuoteAnalyzer() != null &&
+                        positionOffsetGap != fieldType.searchQuoteAnalyzer().getOffsetGap(fieldType.searchQuoteAnalyzer().name())) {
+                    fieldType.setSearchQuoteAnalyzer(new NamedAnalyzer(fieldType.searchQuoteAnalyzer(), positionOffsetGap));                
+                }
             }
             // if the field is not analyzed, then by default, we should omit norms and have docs only
             // index options, as probably what the user really wants


### PR DESCRIPTION
It turns out that Elasticsearch lets the `position_offset_gap`s configured
in the mapping override those configured in the analyzer. I had no idea
that you could configure them in the analyzer at all but that is a base
feature in Lucene and it hasn't been squashed away! The override code assumed
that the defaults were 0 and did a comparison between the value in the mapping
and 0 rather than the vaue in the mapping and the value in the analyzer.
This switches it to comparing between the mapping and the analyzer and adds
a special value (-1) that the mapping default to that means "use whatever
is configured in the analyzer". That value is the default now which is fine
because the custom analyzers default to 10.

Now this isn't quite right because non-custom analyzers will still default to
0 in this case but its closer to right.
